### PR TITLE
Remove color rounding during token import

### DIFF
--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -36,6 +36,10 @@ export function readJsonFiles(files: string[]) {
     seenCollectionsAndModes.add(`${collectionName}.${modeName}`)
 
     const fileContent = fs.readFileSync(file, { encoding: 'utf-8' })
+
+    if (!fileContent) {
+      throw new Error(`Invalid tokens file: ${file}. File is empty.`)
+    }
     const tokensFile: TokensFile = JSON.parse(fileContent)
 
     tokensJsonByFile[baseFileName] = flattenTokensFile(tokensFile)


### PR DESCRIPTION
Remove color rounding during token import now that we've rolled out the REST API fix for high-precision color values

Also handle empty files and add a bunch more tests.

Fixes: https://app.asana.com/0/1203505314277408/1205152183539898/f

## Testing

You can run `npm run sync-tokens-to-figma` locally after making temporary changes to hex values in the tokens files, and check the variables authoring modal in the Figma UI to see that you get the same hex value.

