### PR TITLE
fix: ignore variable mode value if it is a variable alias

### DIFF
--- a/src/sync_tokens_to_figma.ts
+++ b/src/sync_tokens_to_figma.ts
@@ -22,7 +22,7 @@ async function main() {
   const api = new FigmaApi(process.env.PERSONAL_ACCESS_TOKEN)
   const localVariables = await api.getLocalVariables(fileKey)
 
-  const postVariablesPayload = generatePostVariablesPayload(tokensByFile, localVariables)
+  const postVariablesPayload = generatePostVariablesPayload(tokensByFile, localVariables, false)
 
   if (Object.values(postVariablesPayload).every((value) => value.length === 0)) {
     console.log(green('✅ Tokens are already up to date with the Figma file'))

--- a/src/token_import.test.ts
+++ b/src/token_import.test.ts
@@ -277,30 +277,6 @@ describe('generatePostVariablesPayload', () => {
         modeId: 'mode2',
         value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
       },
-
-      // tokens, mode1
-      {
-        variableId: 'spacing/spacing-sm',
-        modeId: 'mode1',
-        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
-      },
-      {
-        variableId: 'surface/surface-brand',
-        modeId: 'mode1',
-        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/radish' },
-      },
-
-      // tokens, mode2
-      {
-        variableId: 'spacing/spacing-sm',
-        modeId: 'mode2',
-        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
-      },
-      {
-        variableId: 'surface/surface-brand',
-        modeId: 'mode2',
-        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/pear' },
-      },
     ])
   })
 
@@ -510,30 +486,6 @@ describe('generatePostVariablesPayload', () => {
         variableId: 'VariableID:2:4',
         modeId: 'mode2',
         value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
-      },
-
-      // tokens, mode1
-      {
-        variableId: 'spacing/spacing-sm',
-        modeId: 'mode1',
-        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:1' },
-      },
-      {
-        variableId: 'surface/surface-brand',
-        modeId: 'mode1',
-        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:3' },
-      },
-
-      // tokens, mode2
-      {
-        variableId: 'spacing/spacing-sm',
-        modeId: 'mode2',
-        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:1' },
-      },
-      {
-        variableId: 'surface/surface-brand',
-        modeId: 'mode2',
-        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:4' },
       },
     ])
   })

--- a/src/token_import.test.ts
+++ b/src/token_import.test.ts
@@ -277,6 +277,30 @@ describe('generatePostVariablesPayload', () => {
         modeId: 'mode2',
         value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
       },
+
+      // tokens, mode1
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/radish' },
+      },
+
+      // tokens, mode2
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/pear' },
+      },
     ])
   })
 
@@ -486,6 +510,30 @@ describe('generatePostVariablesPayload', () => {
         variableId: 'VariableID:2:4',
         modeId: 'mode2',
         value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
+      },
+
+      // tokens, mode1
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:3' },
+      },
+
+      // tokens, mode2
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'VariableID:2:4' },
       },
     ])
   })

--- a/src/token_import.test.ts
+++ b/src/token_import.test.ts
@@ -123,7 +123,7 @@ describe('readJsonFiles', () => {
 })
 
 describe('generatePostVariablesPayload', () => {
-  it('does an initial sync without generating variable mode values', async () => {
+  it('does an initial sync', async () => {
     const localVariablesResponse: GetLocalVariablesResponse = {
       status: 200,
       error: false,
@@ -156,7 +156,98 @@ describe('generatePostVariablesPayload', () => {
       },
     }
 
-    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse, false)
+    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse)
+    expect(result.variableCollections).toEqual([
+      {
+        action: 'CREATE',
+        id: 'primitives',
+        name: 'primitives',
+        initialModeId: 'mode1',
+      },
+      {
+        action: 'CREATE',
+        id: 'tokens',
+        name: 'tokens',
+        initialModeId: 'mode1',
+      },
+    ])
+
+    expect(result.variableModes).toEqual([
+      {
+        action: 'UPDATE',
+        id: 'mode1',
+        name: 'mode1',
+        variableCollectionId: 'primitives',
+      },
+      {
+        action: 'CREATE',
+        id: 'mode2',
+        name: 'mode2',
+        variableCollectionId: 'primitives',
+      },
+      {
+        action: 'UPDATE',
+        id: 'mode1',
+        name: 'mode1',
+        variableCollectionId: 'tokens',
+      },
+      {
+        action: 'CREATE',
+        id: 'mode2',
+        name: 'mode2',
+        variableCollectionId: 'tokens',
+      },
+    ])
+
+    expect(result.variables).toEqual([
+      // variables for the primitives collection
+      {
+        action: 'CREATE',
+        id: 'spacing/1',
+        name: 'spacing/1',
+        variableCollectionId: 'primitives',
+        resolvedType: 'FLOAT',
+        description: '8px spacing',
+      },
+      {
+        action: 'CREATE',
+        id: 'spacing/2',
+        name: 'spacing/2',
+        variableCollectionId: 'primitives',
+        resolvedType: 'FLOAT',
+      },
+      {
+        action: 'CREATE',
+        id: 'color/brand/radish',
+        name: 'color/brand/radish',
+        variableCollectionId: 'primitives',
+        resolvedType: 'COLOR',
+        description: 'Radish color',
+      },
+      {
+        action: 'CREATE',
+        id: 'color/brand/pear',
+        name: 'color/brand/pear',
+        variableCollectionId: 'primitives',
+        resolvedType: 'COLOR',
+      },
+
+      // variables for the tokens collection
+      {
+        action: 'CREATE',
+        id: 'spacing/spacing-sm',
+        name: 'spacing/spacing-sm',
+        variableCollectionId: 'tokens',
+        resolvedType: 'FLOAT',
+      },
+      {
+        action: 'CREATE',
+        id: 'surface/surface-brand',
+        name: 'surface/surface-brand',
+        variableCollectionId: 'tokens',
+        resolvedType: 'COLOR',
+      },
+    ])
 
     expect(result.variableModeValues).toEqual([
       // primitives, mode1
@@ -186,188 +277,32 @@ describe('generatePostVariablesPayload', () => {
         modeId: 'mode2',
         value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
       },
+
+      // tokens, mode1
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode1',
+        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/radish' },
+      },
+
+      // tokens, mode2
+      {
+        variableId: 'spacing/spacing-sm',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
+      },
+      {
+        variableId: 'surface/surface-brand',
+        modeId: 'mode2',
+        value: { type: 'VARIABLE_ALIAS', id: 'color/brand/pear' },
+      },
     ])
-  }),
-    it('does an initial sync', async () => {
-      const localVariablesResponse: GetLocalVariablesResponse = {
-        status: 200,
-        error: false,
-        meta: {
-          variableCollections: {},
-          variables: {},
-        },
-      }
-
-      const tokensByFile: FlattenedTokensByFile = {
-        'primitives.mode1.json': {
-          'spacing/1': { $type: 'number', $value: 8, $description: '8px spacing' },
-          'spacing/2': { $type: 'number', $value: 16 },
-          'color/brand/radish': { $type: 'color', $value: '#ffbe16', $description: 'Radish color' },
-          'color/brand/pear': { $type: 'color', $value: '#ffbe16' },
-        },
-        'primitives.mode2.json': {
-          'spacing/1': { $type: 'number', $value: 8 },
-          'spacing/2': { $type: 'number', $value: 16 },
-          'color/brand/radish': { $type: 'color', $value: '#010101' },
-          'color/brand/pear': { $type: 'color', $value: '#010101' },
-        },
-        'tokens.mode1.json': {
-          'spacing/spacing-sm': { $type: 'number', $value: '{spacing.1}' },
-          'surface/surface-brand': { $type: 'color', $value: '{color.brand.radish}' },
-        },
-        'tokens.mode2.json': {
-          'spacing/spacing-sm': { $type: 'number', $value: '{spacing.1}' },
-          'surface/surface-brand': { $type: 'color', $value: '{color.brand.pear}' },
-        },
-      }
-
-      const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse, true)
-      expect(result.variableCollections).toEqual([
-        {
-          action: 'CREATE',
-          id: 'primitives',
-          name: 'primitives',
-          initialModeId: 'mode1',
-        },
-        {
-          action: 'CREATE',
-          id: 'tokens',
-          name: 'tokens',
-          initialModeId: 'mode1',
-        },
-      ])
-
-      expect(result.variableModes).toEqual([
-        {
-          action: 'UPDATE',
-          id: 'mode1',
-          name: 'mode1',
-          variableCollectionId: 'primitives',
-        },
-        {
-          action: 'CREATE',
-          id: 'mode2',
-          name: 'mode2',
-          variableCollectionId: 'primitives',
-        },
-        {
-          action: 'UPDATE',
-          id: 'mode1',
-          name: 'mode1',
-          variableCollectionId: 'tokens',
-        },
-        {
-          action: 'CREATE',
-          id: 'mode2',
-          name: 'mode2',
-          variableCollectionId: 'tokens',
-        },
-      ])
-
-      expect(result.variables).toEqual([
-        // variables for the primitives collection
-        {
-          action: 'CREATE',
-          id: 'spacing/1',
-          name: 'spacing/1',
-          variableCollectionId: 'primitives',
-          resolvedType: 'FLOAT',
-          description: '8px spacing',
-        },
-        {
-          action: 'CREATE',
-          id: 'spacing/2',
-          name: 'spacing/2',
-          variableCollectionId: 'primitives',
-          resolvedType: 'FLOAT',
-        },
-        {
-          action: 'CREATE',
-          id: 'color/brand/radish',
-          name: 'color/brand/radish',
-          variableCollectionId: 'primitives',
-          resolvedType: 'COLOR',
-          description: 'Radish color',
-        },
-        {
-          action: 'CREATE',
-          id: 'color/brand/pear',
-          name: 'color/brand/pear',
-          variableCollectionId: 'primitives',
-          resolvedType: 'COLOR',
-        },
-
-        // variables for the tokens collection
-        {
-          action: 'CREATE',
-          id: 'spacing/spacing-sm',
-          name: 'spacing/spacing-sm',
-          variableCollectionId: 'tokens',
-          resolvedType: 'FLOAT',
-        },
-        {
-          action: 'CREATE',
-          id: 'surface/surface-brand',
-          name: 'surface/surface-brand',
-          variableCollectionId: 'tokens',
-          resolvedType: 'COLOR',
-        },
-      ])
-
-      expect(result.variableModeValues).toEqual([
-        // primitives, mode1
-        { variableId: 'spacing/1', modeId: 'mode1', value: 8 },
-        { variableId: 'spacing/2', modeId: 'mode1', value: 16 },
-        {
-          variableId: 'color/brand/radish',
-          modeId: 'mode1',
-          value: { r: 1, g: 0.7450980392156863, b: 0.08627450980392157 },
-        },
-        {
-          variableId: 'color/brand/pear',
-          modeId: 'mode1',
-          value: { r: 1, g: 0.7450980392156863, b: 0.08627450980392157 },
-        },
-
-        // primitives, mode2
-        { variableId: 'spacing/1', modeId: 'mode2', value: 8 },
-        { variableId: 'spacing/2', modeId: 'mode2', value: 16 },
-        {
-          variableId: 'color/brand/radish',
-          modeId: 'mode2',
-          value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
-        },
-        {
-          variableId: 'color/brand/pear',
-          modeId: 'mode2',
-          value: { r: 0.00392156862745098, g: 0.00392156862745098, b: 0.00392156862745098 },
-        },
-
-        // tokens, mode1
-        {
-          variableId: 'spacing/spacing-sm',
-          modeId: 'mode1',
-          value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
-        },
-        {
-          variableId: 'surface/surface-brand',
-          modeId: 'mode1',
-          value: { type: 'VARIABLE_ALIAS', id: 'color/brand/radish' },
-        },
-
-        // tokens, mode2
-        {
-          variableId: 'spacing/spacing-sm',
-          modeId: 'mode2',
-          value: { type: 'VARIABLE_ALIAS', id: 'spacing/1' },
-        },
-        {
-          variableId: 'surface/surface-brand',
-          modeId: 'mode2',
-          value: { type: 'VARIABLE_ALIAS', id: 'color/brand/pear' },
-        },
-      ])
-    })
+  })
 
   it('does an in-place update', async () => {
     const localVariablesResponse: GetLocalVariablesResponse = {
@@ -497,7 +432,7 @@ describe('generatePostVariablesPayload', () => {
       },
     }
 
-    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse, false)
+    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse)
     expect(result.variableCollections).toEqual([
       {
         action: 'CREATE',
@@ -684,7 +619,7 @@ describe('generatePostVariablesPayload', () => {
       },
     }
 
-    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse, true)
+    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse)
 
     expect(result).toEqual({
       variableCollections: [],
@@ -775,22 +710,18 @@ describe('generatePostVariablesPayload', () => {
       },
     }
 
-    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse, true)
+    const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse)
 
     // Since all existing collections and variables are remote, result should be equivalent to an initial sync
     expect(result).toEqual(
-      generatePostVariablesPayload(
-        tokensByFile,
-        {
-          status: 200,
-          error: false,
-          meta: {
-            variableCollections: {},
-            variables: {},
-          },
+      generatePostVariablesPayload(tokensByFile, {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {},
+          variables: {},
         },
-        true,
-      ),
+      }),
     )
   })
 
@@ -811,7 +742,7 @@ describe('generatePostVariablesPayload', () => {
     }
 
     expect(() => {
-      generatePostVariablesPayload(tokensByFile, localVariablesResponse, true)
+      generatePostVariablesPayload(tokensByFile, localVariablesResponse)
     }).toThrowError('Invalid token $type: fontWeight')
   })
 
@@ -864,7 +795,7 @@ describe('generatePostVariablesPayload', () => {
     }
 
     expect(() => {
-      generatePostVariablesPayload(tokensByFile, localVariablesResponse, true)
+      generatePostVariablesPayload(tokensByFile, localVariablesResponse)
     }).toThrowError('Duplicate variable collection in file: collection')
   })
 })

--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -9,6 +9,7 @@ import {
   LocalVariable,
   LocalVariableCollection,
   PostVariablesRequestBody,
+  VariableAlias,
   VariableCodeSyntax,
   VariableCreate,
   VariableUpdate,
@@ -358,18 +359,24 @@ export function generatePostVariablesPayload(
       }
 
       const existingVariableValue = variable && variableMode ? variable.valuesByMode[modeId] : null
-      const newVariableValue = variableValueFromToken(token, localVariablesByCollectionAndName)
+      const isVariableAlias = (existingVariableValue as VariableAlias)?.type === 'VARIABLE_ALIAS'
 
-      // Only include the variable mode value in the payload if it's different from the existing value
-      if (
-        existingVariableValue === null ||
-        !compareVariableValues(existingVariableValue, newVariableValue)
-      ) {
-        postVariablesPayload.variableModeValues!.push({
-          variableId,
-          modeId,
-          value: newVariableValue,
-        })
+      //  Ignore variable mode value if it is a variable alias. We can't update remote variable aliases.
+
+      if (!isVariableAlias) {
+        const newVariableValue = variableValueFromToken(token, localVariablesByCollectionAndName)
+
+        // Only include the variable mode value in the payload if it's different from the existing value
+        if (
+          existingVariableValue === null ||
+          !compareVariableValues(existingVariableValue, newVariableValue)
+        ) {
+          postVariablesPayload.variableModeValues!.push({
+            variableId,
+            modeId,
+            value: newVariableValue,
+          })
+        }
       }
     })
   })

--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -370,6 +370,7 @@ export function generatePostVariablesPayload(
         isMissingVariableModeValueInFigma &&
         shouldGenerateVariableModeValuesThatAreMissingInFigma
       ) {
+        // Include the variable mode value in the payload if it is missing and we have chosen to include missing values in the current library
         postVariablesPayload.variableModeValues!.push({
           variableId,
           modeId,
@@ -381,7 +382,7 @@ export function generatePostVariablesPayload(
           valueFromFigma,
           token,
         })
-        // Only include the variable mode value in the payload if it's different from the existing value
+        // Include the variable mode value in the payload if it's different from the existing value
         if (isDifferent) {
           postVariablesPayload.variableModeValues!.push({
             variableId,

--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -239,7 +239,7 @@ function tokenAndVariableDifferences(token: Token, variable: LocalVariable | nul
 export function generatePostVariablesPayload(
   tokensByFile: FlattenedTokensByFile,
   localVariables: GetLocalVariablesResponse,
-  shouldGenerateVariableModeValuesThatAreMissingInFigma: boolean,
+  shouldGenerateVariableModeValuesThatAreMissingInFigma: boolean = true,
 ) {
   const localVariableCollectionsByName: { [name: string]: LocalVariableCollection } = {}
   const localVariablesByCollectionAndName: {

--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -359,13 +359,11 @@ export function generatePostVariablesPayload(
       }
 
       const existingVariableValue = variable && variableMode ? variable.valuesByMode[modeId] : null
-      const isVariableAlias = (existingVariableValue as VariableAlias)?.type === 'VARIABLE_ALIAS'
-
+      const newVariableValue = variableValueFromToken(token, localVariablesByCollectionAndName)
       //  Ignore variable mode value if it is a variable alias. We can't update remote variable aliases.
+      const isVariableAlias = (newVariableValue as VariableAlias)?.type === 'VARIABLE_ALIAS'
 
       if (!isVariableAlias) {
-        const newVariableValue = variableValueFromToken(token, localVariablesByCollectionAndName)
-
         // Only include the variable mode value in the payload if it's different from the existing value
         if (
           existingVariableValue === null ||


### PR DESCRIPTION
If the variable mode value is referencing a remote variable we should ignore it when generating the post variables payload. 