### PR TITLE
Fix bug where aliases to remote variables could not be updated when syncing tokens to Figma

### DIFF
--- a/src/token_import.test.ts
+++ b/src/token_import.test.ts
@@ -712,7 +712,6 @@ describe('generatePostVariablesPayload', () => {
 
     const result = generatePostVariablesPayload(tokensByFile, localVariablesResponse)
 
-    // Since all existing collections and variables are remote, result should be equivalent to an initial sync
     expect(result).toEqual({
       variableCollections: [],
       variableModes: [],
@@ -802,7 +801,6 @@ describe('generatePostVariablesPayload', () => {
       },
     }
 
-    // Since all existing collections and variables are remote, result should be equivalent to an initial sync
     expect(() => {
       generatePostVariablesPayload(tokensByFile, localVariablesResponse)
     }).toThrowError(`Cannot update remote variable "var1" in collection "collection"`)

--- a/src/token_import.ts
+++ b/src/token_import.ts
@@ -242,11 +242,6 @@ export function generatePostVariablesPayload(
   } = {}
 
   Object.values(localVariables.meta.variableCollections).forEach((collection) => {
-    // Skip over remote collections because we can't modify them
-    if (collection.remote) {
-      return
-    }
-
     if (localVariableCollectionsByName[collection.name]) {
       throw new Error(`Duplicate variable collection in file: ${collection.name}`)
     }
@@ -255,11 +250,6 @@ export function generatePostVariablesPayload(
   })
 
   Object.values(localVariables.meta.variables).forEach((variable) => {
-    // Skip over remote variables because we can't modify them
-    if (variable.remote) {
-      return
-    }
-
     if (!localVariablesByCollectionAndName[variable.variableCollectionId]) {
       localVariablesByCollectionAndName[variable.variableCollectionId] = {}
     }
@@ -350,6 +340,12 @@ export function generatePostVariablesPayload(
           ...differences,
         })
       } else if (variable && Object.keys(differences).length > 0) {
+        if (variable.remote) {
+          throw new Error(
+            `Cannot update remote variable "${variable.name}" in collection "${collectionName}"`,
+          )
+        }
+
         postVariablesPayload.variables!.push({
           action: 'UPDATE',
           id: variableId,


### PR DESCRIPTION
For the `sync_tokens_to_figma.ts` script, if a tokens file has aliases to variables in remote collections, e.g. `"$value": "{name_of_variable}"`, update those alias references when needed. This issue was brought up in https://github.com/figma/variables-github-action-example/pull/20.

The previous behavior was that if a tokens file has aliases to variables in a remote collection, those aliases would cause a 400 response from the `POST /v1/files/:file_key/variables` endpoint, as the script was sending up invalid variable ids inside the alias objects.

Now, the script will match up token values with remote variable names and update aliases when needed.

Note: we are limited by the variables API in that we cannot alias variables that aren't already consumed by current file.

Demo:

Here is a demo of the `sync_tokens_to_figma.ts` script updating a Figma file that has a Semantic variables collection with aliases to variables published from another file.

https://github.com/figma/variables-github-action-example/assets/250513/592fddbc-38fe-485c-89ca-688b1777b64f

## Test Plan

- In one file, create and publish a variable collection
- In another file, create a variable collection with variables that alias to variables from the file above
- Run `npm run sync-figma-to-tokens` to export the variables from the second file into a tokens file
- Run `npm run sync-tokens-to-figma` on the exported tokens file to sync the tokens back to Figma. The result is that we should noop instead of getting a 400 error from the REST API.

